### PR TITLE
fix(ios): regenerate .entitlements for out-of-project export paths

### DIFF
--- a/addon/src/DeeplinkPlugin.gd
+++ b/addon/src/DeeplinkPlugin.gd
@@ -209,10 +209,8 @@ class IosExportPlugin extends EditorExportPlugin:
 
 	func _export_directory_path_for_entitlements(a_export_path: String) -> String:
 		var __directory_path := a_export_path.trim_suffix(EXPORT_FILE_SUFFIX)
-		if __directory_path.begins_with("res://") or __directory_path.begins_with("user://"):
-			return ProjectSettings.globalize_path(__directory_path)
 		if __directory_path.is_absolute_path():
-			return __directory_path
+			return ProjectSettings.globalize_path(__directory_path)
 		return ProjectSettings.globalize_path("res://" + __directory_path)
 
 

--- a/addon/src/DeeplinkPlugin.gd
+++ b/addon/src/DeeplinkPlugin.gd
@@ -239,8 +239,10 @@ class IosExportPlugin extends EditorExportPlugin:
 						Deeplink.log_error("Couldn't open file '%s' for writing." % __file_path)
 				else:
 					Deeplink.log_error("Directory '%s' doesn't exist." % __directory_path)
-			else:
-				Deeplink.log_error("Unexpected export path '%s'" % _export_path)
+			# No else: _export_end() is invoked for every export platform, but
+			# entitlements only apply to iOS (.ipa) exports. A non-.ipa path
+			# (Android, desktop) is not an error — there is simply nothing to
+			# regenerate.
 		else:
 			Deeplink.log_error("Export path is not defined.")
 

--- a/addon/src/DeeplinkPlugin.gd
+++ b/addon/src/DeeplinkPlugin.gd
@@ -207,12 +207,19 @@ class IosExportPlugin extends EditorExportPlugin:
 		_regenerate_entitlements_file()
 
 
+	func _export_directory_path_for_entitlements(a_export_path: String) -> String:
+		var __directory_path := a_export_path.trim_suffix(EXPORT_FILE_SUFFIX)
+		if __directory_path.begins_with("res://") or __directory_path.begins_with("user://"):
+			return ProjectSettings.globalize_path(__directory_path)
+		if __directory_path.is_absolute_path():
+			return __directory_path
+		return ProjectSettings.globalize_path("res://" + __directory_path)
+
+
 	func _regenerate_entitlements_file() -> void:
 		if _export_path:
 			if _export_path.ends_with(EXPORT_FILE_SUFFIX):
-				var __project_path = ProjectSettings.globalize_path("res://")
-				Deeplink.log_info("******** PROJECT PATH='%s'" % __project_path)
-				var __directory_path = "%s%s" % [__project_path, _export_path.trim_suffix(EXPORT_FILE_SUFFIX)]
+				var __directory_path = _export_directory_path_for_entitlements(_export_path)
 				if DirAccess.dir_exists_absolute(__directory_path):
 					var __project_name = _get_project_name_from_path(__directory_path)
 					var __file_path = "%s/%s.entitlements" % [__directory_path, __project_name]


### PR DESCRIPTION
## Summary

`IosExportPlugin._regenerate_entitlements_file()` derived the export directory by unconditionally prepending the project root (`globalize_path("res://")`) to `_export_path`. This only produces a valid path when the iOS export path is a project-relative fragment.

When the export path is absolute (e.g. `/tmp/out/app.ipa`) or otherwise outside the project tree, the concatenation yields a malformed path like `/Users/.../project//tmp/out/app`. `DirAccess.dir_exists_absolute()`
then returns `false`, so the plugin silently skips writing `<app>.entitlements`; logging only a non-fatal error while the export still reports success. Since that file carries the Associated Domains (`applinks:`) entries, Universal Links are broken in any such build.

## Fix

Add `_export_directory_path_for_entitlements()`, which resolves the export directory from the path's actual form:

- globalize `res://` / `user://` URIs
- pass filesystem-absolute paths through unchanged
- only prepend the project root for genuinely relative fragments

The `res://` / `user://` check runs before the absolute-path check because Godot's `String.is_absolute_path()` also returns `true` for those URIs.

## Testing

Manual via the demo app: iOS export to an absolute out-of-project path now writes `<app>.entitlements` with the configured `applinks:` entries; relative in-project export paths continue to work as before.

Fixes #15